### PR TITLE
Support outfits update

### DIFF
--- a/message/us/uses/table.json
+++ b/message/us/uses/table.json
@@ -22,5 +22,10 @@
     "combat_ui_disabled_helptext": "Oculta la interfaz durante el combate.",
     "ring_polish_rumble_menu_item_name": "Vibración al pulir anillos",
     "ring_dlc_polish_rumble_menu_item_name": "Vibración al pulir anillos/brazaletes",
+    "support_outfit_item_name": "Atuendo en las relaciones de apoyo",
+    "support_outfit_item_enabled_commandtext": "Batalla",
+    "support_outfit_item_disabled_commandtext": "Normal",
+    "support_outfit_item_enabled_helptext": "Los personajes usarán su atuendo de batalla.",
+    "support_outfit_item_disabled_helptext": "Los personajes usarán su atuendo normal.",
     "localization_authors": "TheRutileMarmot, GezelVT"
 }


### PR DESCRIPTION
Love it when a sentence in spanish wants to be about 3 times longer than in english (: 

Technically my translation for the helptexts doesn't specify that they'll use battle/default attire _only_ during support conversations.
I can change that if absolute clarity is desired, but I think the item_name has that covered!